### PR TITLE
Fixes #9, Add check for userConfig to be an array

### DIFF
--- a/src/Library/App.php
+++ b/src/Library/App.php
@@ -94,7 +94,9 @@ class App
         if ($this->exists()) {
             $configFilePath = $this->configFilePath();
             $userConfig = require($configFilePath);
-            $this->config = array_merge($this->config, $userConfig);
+            if (is_array($userConfig)) {
+                $this->config = array_merge($this->config, $userConfig);
+            }
         }
     }
 


### PR DESCRIPTION
if the config file does not exist require will return an integer leading to a type error on the next line. Closes #9 